### PR TITLE
[BUG] Object Distortion fix in Example - Cube VR

### DIFF
--- a/libraries/vr/examples/Cube/Cube.pde
+++ b/libraries/vr/examples/Cube/Cube.pde
@@ -10,5 +10,5 @@ void draw() {
   translate(width/2, height/2);
   rotateX(frameCount * 0.01f);
   rotateY(frameCount * 0.01f);  
-  box(500);
+  box(350);
 }


### PR DESCRIPTION
closes [#448](https://github.com/processing/processing-android/issues/448)